### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,15 +1,15 @@
 ##
 ## Syntax Highlighting for Arduino IDE
 ##
-JoyAxis     KEYWORD1
-value       KEYWORD2
-centerValue KEYWORD2
-isAtCenter  KEYWORD2
+JoyAxis	KEYWORD1
+value	KEYWORD2
+centerValue	KEYWORD2
+isAtCenter	KEYWORD2
 
-Joystick       KEYWORD1
-update         KEYWORD2
-print          KEYWORD2
-getButtonEvent KEYWORD2
-X              KEYWORD2
-Y              KEYWORD2
+Joystick	KEYWORD1
+update	KEYWORD2
+print	KEYWORD2
+getButtonEvent	KEYWORD2
+X	KEYWORD2
+Y	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords